### PR TITLE
Fixing KeyError details Lambdas CIS_2-9_RR & CIS_1-3_1-4_RR

### DIFF
--- a/SecurityHub_CISPlaybooks_CloudFormation.yaml
+++ b/SecurityHub_CISPlaybooks_CloudFormation.yaml
@@ -100,7 +100,7 @@ Resources:
           import datetime
           import os
           def lambda_handler(event, context):
-              nonRotatedKeyUser = str(event['detail']['findings'][0]['Resources'][0]['Details']['Other']['userName'])
+              nonRotatedKeyUser = str(event['detail']['findings'][0]['Resources'][0]['Id']).rsplit('/', 1)[-1]
               findingId = str(event['detail']['findings'][0]['Id'])
               lambdaFunctionName = os.environ['AWS_LAMBDA_FUNCTION_NAME']
               # Create bot3 clients and resource
@@ -1024,7 +1024,7 @@ Resources:
           import os
           def lambda_handler(event, context):
               # Grab non-logged VPC ID from Security Hub finding
-              noncompliantVPC = str(event['detail']['findings'][0]['Resources'][0]['Details']['Other']['vpcId'])
+              noncompliantVPC = str(event['detail']['findings'][0]['Resources'][0]['Id']).rsplit('/', 1)[-1]
               findingId = str(event['detail']['findings'][0]['Id'])
               # import lambda runtime vars
               lambdaFunctionName = os.environ['AWS_LAMBDA_FUNCTION_NAME']


### PR DESCRIPTION
Issue:
When executing Lambdas for CIS 2.9, CIS 1.3 and CIS 1.4 you get "[ERROR] KeyError: 'Details'" due to params "nonRotatedKeyUser" and "noncompliantVPC" not being formatted in same way as the CloudWatch event.

For example, Event in Security Hub for CIS 1.4 looks like this:
```
"Resources": [
    {
      "Type": "AwsIamUser",
      "Id": "arn:aws:iam::333333333333:user/user1",
      "Partition": "aws",
      "Region": "eu-west-1"
    }
  ],
```

Lambda CIS_1-3_1-4_RR that is responsing to this event is catching ```nonRotatedKeyUser = str(event['detail']['findings'][0]['Resources'][0]['Details']['Other']['userName'])``` and error ```[ERROR] KeyError: 'Details'``` persist.
Suggested changes with included rsplit makes this format correct.

