### PR TITLE
Adding iam:PassRole CIS29RRLambdaRole due to UnauthorizedOperation

### DIFF
--- a/SecurityHub_CISPlaybooks_CloudFormation.yaml
+++ b/SecurityHub_CISPlaybooks_CloudFormation.yaml
@@ -1115,6 +1115,10 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Action:
+            - iam:PassRole
+            Resource: '*'
+          - Effect: Allow
+            Action:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents


### PR DESCRIPTION
CIS29RRLambdaRole needs iam:PassRole permissions to be able to enable Flow logs, else error `An error occurred (UnauthorizedOperation) when calling the CreateFlowLogs operation: You are not authorized to perform this operation.` will occur.
